### PR TITLE
Run the prerequisites.sh script before building a package, if present

### DIFF
--- a/build_pkg.sh
+++ b/build_pkg.sh
@@ -27,6 +27,9 @@ if [[ $ABI = 32 ]]; then
 fi
 
 # build this package, if necessary
+if [[ -x prerequisites.sh ]]; then
+    ./prerequisites.sh
+fi
 if [[ -x autogen.sh ]]; then
     ./autogen.sh
     ./configure --with-gaproot=$GAPROOT


### PR DESCRIPTION
This should allow the Semigroups package to automatically use GitHub actions using the `gap-actions` workflows - see https://github.com/semigroups/Semigroups/pull/717 for context.