### PR TITLE
Pass GAPROOT to prerequisites.sh

### DIFF
--- a/build_pkg.sh
+++ b/build_pkg.sh
@@ -28,7 +28,7 @@ fi
 
 # build this package, if necessary
 if [[ -x prerequisites.sh ]]; then
-    ./prerequisites.sh
+    ./prerequisites.sh $GAPROOT
 fi
 if [[ -x autogen.sh ]]; then
     ./autogen.sh


### PR DESCRIPTION
ping @wilfwilson @ssiccha this should make `prerequisites.sh` more useful, and AFAICT it won't hurt the use in Semigroups