### PR TITLE
Don't be verbose when building GAP

### DIFF
--- a/build_gap.sh
+++ b/build_gap.sh
@@ -28,14 +28,13 @@ if test -x ./autogen.sh ; then
   BuildPackagesOptions="--strict"
   ./autogen.sh
   ./configure $GAP_CONFIGFLAGS
-  make -j4 V=1
 else
   # must be GAP 4.8 or older
   BuildPackagesOptions="$PWD"
   ./configure --with-gmp=system $GAP_CONFIGFLAGS
   make config
-  make -j4
 fi
+make -j4
 
 # download packages; instruct wget to retry several times if the
 # connection is refused, to work around intermittent failures


### PR DESCRIPTION
There should rarely be issues compiling GAP, and then they most
likely should be debugged on the GAP side. So use the default quiet
output here, to make package CI build logs a bit more manageable.