### PR TITLE
Add option to use a custom fork of GAP (default: gap-system)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ TODO: mention `.codecov.yml` (perhaps also Coveralls); also `NO_COVERAGE`
 - `GAP_CONFIGFLAGS` -- optional configure flags to pass to GAP's configure script
 - `GAP_PKGS_TO_BUILD` -- see above for an explanation
 - `GAP_PKGS_TO_CLONE` -- see above for an explanation
+- `GAPFORK` -- the GitHub fork of GAP to use (default: `gap-system`)
 - `GAPBRANCH` -- the GAP branch to use (default: `master`)
 - `GAPROOT` -- the the location GAP is (to be) installed at (default: `$HOME/gap`)
 - `GAP_TESTFILE` -- the file read by `run_tests.sh` (default: `tst/testall.g`)

--- a/build_gap.sh
+++ b/build_gap.sh
@@ -15,7 +15,7 @@ set -ex
 GAPROOT=${GAPROOT-$HOME/gap}
 
 # clone GAP into a subdirectory
-git clone --depth=2 -b ${GAPBRANCH:-master} https://github.com/gap-system/gap.git $GAPROOT
+git clone --depth=2 -b ${GAPBRANCH:-master} https://github.com/${GAPFORK:-gap-system}/gap.git $GAPROOT
 cd $GAPROOT
 
 # for HPC-GAP, add suitable flags


### PR DESCRIPTION
I intend to update `gap-actions/setup-gap` to accept and pass on this option too.

My use case is as follows: If I am preparing a PR for GAP, and I want to make corresponding changes to a GAP package (or just check that the package still works properly against the new GAP PR), then I can temporarily use `GAPFORK=wilfwilson` and `GAPBRANCH=pr-branch` in the package's CI to see how it all works together.

I could achieve this behaviour currently by pushing my branch to `gap-system/gap`, but I prefer not to do that.