### PR TITLE
Add a `.gitattributes` file to use Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
I'm not exactly sure what this is all about, but we made the same change for GAP (see https://github.com/gap-system/gap/pull/4414/files#r616159392) so I think it's safe.

In particular, this change let me convert the `gap-actions` scripts to be usable in Windows/Cygwin without needing to do the following:
```
      - name: "Set git to use UNIX-style line endings"
        run: |
          git config --global core.autocrlf false
          git config --global core.eol lf
```

(Even though we're going to move the `gap-actions` stuff away from using `pkg-ci-scripts` - https://github.com/gap-actions/setup-gap/issues/25 - that's not done yet, and so I would like this PR to be merged in the interim.)